### PR TITLE
Remove jobs from search

### DIFF
--- a/wp-content/themes/workingnyc/search.php
+++ b/wp-content/themes/workingnyc/search.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once WorkingNYC\timber_post('Jobs');
 require_once WorkingNYC\timber_post('Programs');
 
 // Get the search term
@@ -24,6 +23,8 @@ $context['term'] = $term;
 $context['posts'] = array_map(function($p) {
     return new WorkingNYC\Programs($p);
 }, $posts);
+
+// TODO: add translations to search
 // $context['language'] = ICL_LANGUAGE_CODE;
 
 // Render view

--- a/wp-content/themes/workingnyc/search.php
+++ b/wp-content/themes/workingnyc/search.php
@@ -3,18 +3,13 @@
 require_once WorkingNYC\timber_post('Jobs');
 require_once WorkingNYC\timber_post('Programs');
 
-// Add javascript for filtering search results
-add_action('wp_enqueue_scripts', function() {
-  enqueue_script('search');
-});
-
 // Get the search term
 $term = (isset($_GET['s'])) ? $_GET['s'] : '';
 
 // Create query
 $wp_query = new WP_Query(array(
   's' => $term,
-  'post_type' => array('programs', 'jobs')
+  'post_type' => array('programs')
 ));
 
 // Redo relevanssi query and get posts in Timber format.
@@ -27,11 +22,7 @@ $posts = Timber::get_posts($wp_query_ids);
 $context = Timber::get_context();
 $context['term'] = $term;
 $context['posts'] = array_map(function($p) {
-  if ($p->post_type == 'programs') {
     return new WorkingNYC\Programs($p);
-  } else {
-    return new WorkingNYC\Jobs($p);
-  }
 }, $posts);
 // $context['language'] = ICL_LANGUAGE_CODE;
 

--- a/wp-content/themes/workingnyc/views/search/search-results.twig
+++ b/wp-content/themes/workingnyc/views/search/search-results.twig
@@ -35,24 +35,10 @@
                 {{ __('Showing 1 result for "{{ TERM }}".', 'WNYC')|replace({'{{ TERM }}': term}) }}
               {% endif %}
             </h2>
-            <div class="mb-4">
-              <button class="btn-tag btn-primary" id='all-button'>{{__('All', 'WNYC')}}</button>
-              <button class="btn-tag" id='jobs-button'>{{__('Jobs', 'WNYC')}}</button>
-              <button class="btn-tag" id='programs-button'>{{__('Programs', 'WNYC')}}</button>
-            </div>
             {% endblock %}
             <div class="grid gap-3 desktop:grid-cols-2 mb-3">
               {% block post_list %}
                 {% for post in posts %}
-                  {% if post.post_type == 'jobs' %}
-                    <div data-js="search-result" data-js-result-type="job">
-                      {% include 'jobs/job.twig' with {
-                        this: {
-                          post: post
-                        }
-                      } %}
-                    </div>
-                  {% elseif post.post_type == 'programs' %}
                     <div data-js="search-result" data-js-result-type="program">
                       {% include 'programs/program.twig' with {
                         this: {
@@ -60,7 +46,6 @@
                         }
                       } %}
                     </div>
-                  {% endif %}
                 {% endfor %}
               {% endblock %}
             </div>


### PR DESCRIPTION
Jobs have been removed from the site, so we can remove jobs from the search results as well.

Before:
<img width="1701" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/cde3d3e0-3424-4cdf-a541-080dd4be5be6">

After:

<img width="1652" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/7bbe5406-bbf5-4f67-a132-4c36a32cd74a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined search functionality to focus exclusively on 'programs', removing 'jobs' from the search scope.
  
- **Style**
  - Updated search results page to remove filter buttons, simplifying the user interface.

- **Bug Fixes**
  - Removed unnecessary JavaScript actions to enhance search performance and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->