### PR TITLE
Fix htmlspecialchars bug

### DIFF
--- a/wp-content/themes/workingnyc/template-landing-page.php
+++ b/wp-content/themes/workingnyc/template-landing-page.php
@@ -45,7 +45,7 @@ if ($post->slug === 'newsletter') {
   // Populated email from newsletter object
   if (isset($_REQUEST['EMAIL'])) {
     if ($_REQUEST['EMAIL'] != "") {
-      $context['email'] = htmlspecialchars($_REQUEST['EMAIL'], 'ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401');
+      $context['email'] = htmlspecialchars($_REQUEST['EMAIL']);
       $context['newsletter_message'] = true;
     }
 


### PR DESCRIPTION
I had previously added a flag to the htmlspecialchars PHP function that may not exist in our version of PHP, and it caused the newsletter page to not display the email address the user entered. In this branch, I removed the flag, and the error went away

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the encoding of email input to enhance compatibility and user experience on the landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->