### PR TITLE
Navigation logic (job seekers vs employers) and placeholders

### DIFF
--- a/wp-content/mu-plugins/register-menus.php
+++ b/wp-content/mu-plugins/register-menus.php
@@ -9,7 +9,7 @@
 add_action('init', function() {
   register_nav_menus(
     array(
-      'header_menu' => __('Header Menu', 'Header Menu'),
+      'job_seeker_header_menu' => __('Job Seeker Header Menu', 'Header Menu'),
       'footer_menu' => __('Footer Menu', 'Footer Menu'),
       'footer_menu_secondary' => __('Secondary Footer', 'Footer Menu'),
       'footer_menu_tertiary' => __('Tertiary Footer', 'Footer Menu')

--- a/wp-content/themes/workingnyc/archive.php
+++ b/wp-content/themes/workingnyc/archive.php
@@ -144,6 +144,11 @@ $context['posts'] = array_map(function($p) use ($class) {
   return new $class($p);
 }, Timber::get_posts());
 
+if ($path === 'employer-programs') {
+  // set this to true for all employer-side pages
+  $context['employer'] = true;
+}
+
 /**
  * Render the view
  *

--- a/wp-content/themes/workingnyc/single-employer-programs.php
+++ b/wp-content/themes/workingnyc/single-employer-programs.php
@@ -26,6 +26,9 @@ $context['modified_date'] = WorkingNYC\modified_date_formatted($post->ID);
 
 $context['meta'] = new WorkingNYC\Meta($post);
 
+// set this to true for all employer-side pages
+$context['employer'] = true;
+
 /**
  * Generate schema for page
  *

--- a/wp-content/themes/workingnyc/template-employer-home-page.php
+++ b/wp-content/themes/workingnyc/template-employer-home-page.php
@@ -30,6 +30,9 @@ $post = Timber::get_post();
 
 $context['post'] = $post;
 
+// set this to true for all employer-side pages
+$context['employer'] = true;
+
 /**
  * Get the 4 top announcements based on menu order
  *

--- a/wp-content/themes/workingnyc/template-talent-portal-generic-page.php
+++ b/wp-content/themes/workingnyc/template-talent-portal-generic-page.php
@@ -20,6 +20,9 @@ $context['meta'] = new WorkingNYC\Meta($post);
 
 $context['sections'] = Templating\get_sections();
 
+// set this to true for all employer-side pages
+$context['employer'] = true;
+
 /**
  * Render the view
  */

--- a/wp-content/themes/workingnyc/template-talent-portal-landing-page.php
+++ b/wp-content/themes/workingnyc/template-talent-portal-landing-page.php
@@ -18,6 +18,8 @@ $post = Timber::get_post();
 
 $context['post'] = $post;
 
+$context['talent_portal_landing_page'] = true;
+
 /**
  * Set Meta context
  */

--- a/wp-content/themes/workingnyc/timber-posts/Site.php
+++ b/wp-content/themes/workingnyc/timber-posts/Site.php
@@ -46,7 +46,7 @@ class Site extends TimberSite {
      * Menus
      */
 
-    $context['header_menu'] = new TimberMenu('header_menu');
+    $context['job_seeker_header_menu'] = new TimberMenu('job_seeker_header_menu');
 
     $context['footer_menu'] = new TimberMenu('footer_menu');
 

--- a/wp-content/themes/workingnyc/views/objects/menu.twig
+++ b/wp-content/themes/workingnyc/views/objects/menu.twig
@@ -19,9 +19,13 @@
       <nav class="o-menu__nav" aria-label="{{ __('Menu', 'WNYC') }}">
         <a class="o-menu__nav-item" href="{{ site.url }}" tabindex="-1">{{ __('Home', 'WNYC') }}</a>
 
-        {% for menu_item in header_menu.get_items %}
+        {% if employer == true %}
+        {# Add employer menu items here #}
+        {% else %}
+        {% for menu_item in job_seeker_header_menu.get_items %}
         <a class="o-menu__nav-item" href="{{ menu_item.link }}" tabindex="-1">{{ menu_item.title }}</a>
         {% endfor %}
+        {% endif %}
       </nav>
     </div>
   </div>

--- a/wp-content/themes/workingnyc/views/objects/navigation.twig
+++ b/wp-content/themes/workingnyc/views/objects/navigation.twig
@@ -1,4 +1,8 @@
-<nav aria-label="{{ header_menu.name }}" class="o-navigation o-navigation-fixed" data-js="navigation">
+{% if employer == true %}
+<nav aria-label="TODO" class="o-navigation o-navigation-fixed" data-js="navigation">
+{% else %}
+<nav aria-label="{{ job_seeker_header_menu.name }}" class="o-navigation o-navigation-fixed" data-js="navigation">
+{% endif %}
   <a class="o-navigation__home o-navigation__menu-item bg-scale-1 tablet:bg-transparent" href="{{ site.url }}">
     <span class="sr-only">Job Ready by Jobs N Y C</span>
 
@@ -11,9 +15,15 @@
     </svg>
   </a>
 
-  {% for menu_item in header_menu.get_items %}
-  <a class="o-navigation__item" href="{{ menu_item.link }}">{{ menu_item.title }}</a>
-  {% endfor %}
+  {% if talent_portal_landing_page == false %}
+    {% if employer == true %}
+    {# Add employer menu items here #}
+    {% else %}
+      {% for menu_item in job_seeker_header_menu.get_items %}
+      <a class="o-navigation__item" href="{{ menu_item.link }}">{{ menu_item.title }}</a>
+      {% endfor %}
+    {% endif %}
+  {% endif %}
 
   <button class="o-navigation__menu-item" aria-controls="aria-c-text-controller" aria-expanded="false" data-dialog="open" data-dialog-lock="true" data-js="dialog">
     <svg class="o-navigation__menu-icon icon-ui">
@@ -23,6 +33,7 @@
     <span class="o-navigation__menu-label">{{ __('Languages', 'WNYC') }}</span>
   </button>
   
+  {% if talent_portal_landing_page == false and employer == false %}
   <button class="o-navigation__item desktop:m-0" aria-controls="aria-c-search" aria-expanded="false" data-dialog="open" data-js="search">
     <svg class="o-navigation__menu-icon icon-ui">
       <title>{{__('Search', 'WNYC')}}</title>
@@ -30,6 +41,7 @@
     </svg>
     <span class="o-navigation__menu-label">{{__('Search', 'WNYC') }}</span>
   </button>
+  {% endif %}
 
   <button class="o-navigation__menu-item desktop:hidden mie-0" aria-controls="aria-c-menu" aria-expanded="false" data-js="menu" data-js-menu="open">
     <svg class="o-navigation__menu-icon icon-ui">


### PR DESCRIPTION
Made it so that the job seeker navigation only shows up on job seeker pages. There are placeholders that need to be filled in for the employer navigation. 

<img width="1768" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/f093f947-1e12-4109-8d1a-71d489e6611b">

<img width="1761" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/40a13766-6b8a-4614-8a9c-ea9f3c2ca6be">

<img width="1771" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/35c282b7-8c2f-47b5-ac8c-813a88cb3013">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed menu identifier to better reflect its purpose for job seekers.
- **New Features**
	- Implemented conditional logic to display tailored content for employer-side pages.
	- Added specific content for the talent portal landing page.
- **Style**
	- Adjusted navigation elements to cater to different user types (employer or job seeker).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->