### PR TITLE
change_jobnyc_landing_page_logo_purple_to_black

### DIFF
--- a/wp-content/themes/workingnyc/views/talent-portal-landing-page.twig
+++ b/wp-content/themes/workingnyc/views/talent-portal-landing-page.twig
@@ -6,7 +6,7 @@
     <div class="layout-content text-center py-5">
       <svg aria-hidden="true" class="h-5 mb-2">
         <title>{{ __('Jobs NYC', 'WNYC') }}</title>
-        <use href="#Jobs-NYC-Telent-Portal-logo"></use>
+        <use href="#Telent-Portal-logo"></use>
       </svg>
       <div>
         {{ post.post_content }}


### PR DESCRIPTION
Task- 14 Change JOBNYC  landing page logo purple to black

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the reference for the SVG element in the Talent Portal landing page for improved logo display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->