### PR TITLE
Create job boards post type

### DIFF
--- a/wp-content/mu-plugins/register-post-types.php
+++ b/wp-content/mu-plugins/register-post-types.php
@@ -300,5 +300,4 @@ add_action('init', function() {
       'with_front' => false
     )
   ));
-
 });

--- a/wp-content/mu-plugins/register-post-types.php
+++ b/wp-content/mu-plugins/register-post-types.php
@@ -258,4 +258,47 @@ add_action('init', function() {
       'with_front' => false
     )
   ));
+
+  /**
+   * Post Type: Employer Programs
+   *
+   * @author NYC Opportunity
+   */
+  register_post_type('job-boards', array(
+    'labels' => array(
+      'name' => __('Job Boards'),
+      'singular_name' => __('Job Board'),
+      'all_items' => __('All Job Boards'),
+      'add_new' => __('Add New'),
+      'add_new_item' => __('Add New Job Board'),
+      'edit' => __('Edit'),
+      'edit_item' => __('Edit Job Board'),
+      'new_item' => __('New Job Board'),
+      'view_item' => __('View Job Board'),
+      'search_items' => __('Search Job Boards')
+    ),
+    'description' => __('Job boards'),
+    'public' => true,
+    'show_in_rest' => true,
+    'exclude_from_search' => false,
+    'show_ui' => true,
+    'hierarchical' => false,
+    'supports' => ['title', 'page-attributes'],
+
+    /**
+     * @source https://developer.wordpress.org/resource/dashicons/
+     */
+    'menu_icon' => 'dashicons-store',
+
+    /**
+     * Use the registration order to enforce menu position
+     */
+    'menu_position' => 21,
+    'has_archive' => true,
+    'rewrite' => array(
+      'slug' => 'jobseekers/job-boards',
+      'with_front' => false
+    )
+  ));
+
 });

--- a/wp-content/mu-plugins/register-post-types.php
+++ b/wp-content/mu-plugins/register-post-types.php
@@ -288,7 +288,7 @@ add_action('init', function() {
     /**
      * @source https://developer.wordpress.org/resource/dashicons/
      */
-    'menu_icon' => 'dashicons-store',
+    'menu_icon' => 'dashicons-clipboard',
 
     /**
      * Use the registration order to enforce menu position

--- a/wp-content/themes/workingnyc/acf-json/group_5f298dbb5dda2.json
+++ b/wp-content/themes/workingnyc/acf-json/group_5f298dbb5dda2.json
@@ -112,7 +112,8 @@
                                 "programs",
                                 "jobs",
                                 "guides",
-                                "employer-programs"
+                                "employer-programs",
+                                "job-boards"
                             ],
                             "taxonomy": "",
                             "filters": [
@@ -423,6 +424,13 @@
                 "operator": "==",
                 "value": "template-employer-home-page.php"
             }
+        ],
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "template-employ-nyc-landing-page.php"
+            }
         ]
     ],
     "menu_order": 1,
@@ -434,5 +442,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1708719931
+    "modified": 1710878708
 }

--- a/wp-content/themes/workingnyc/acf-json/group_5f298dbb5dda2.json
+++ b/wp-content/themes/workingnyc/acf-json/group_5f298dbb5dda2.json
@@ -424,13 +424,6 @@
                 "operator": "==",
                 "value": "template-employer-home-page.php"
             }
-        ],
-        [
-            {
-                "param": "page_template",
-                "operator": "==",
-                "value": "template-employ-nyc-landing-page.php"
-            }
         ]
     ],
     "menu_order": 1,
@@ -442,5 +435,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1710878708
+    "modified": 1710944509
 }

--- a/wp-content/themes/workingnyc/acf-json/group_65f9ee7823cd4.json
+++ b/wp-content/themes/workingnyc/acf-json/group_65f9ee7823cd4.json
@@ -1,0 +1,81 @@
+{
+    "key": "group_65f9ee7823cd4",
+    "title": "Job boards fields",
+    "fields": [
+        {
+            "key": "field_65f9ee8967573",
+            "label": "Agency",
+            "name": "agency",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "relevanssi_exclude": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_65f9ee9267574",
+            "label": "Description",
+            "name": "description",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "relevanssi_exclude": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_65f9ee9d67575",
+            "label": "CTA Link",
+            "name": "cta_link",
+            "type": "link",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "relevanssi_exclude": 0,
+            "return_format": "array"
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "job-boards"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "modified": 1710878381
+}

--- a/wp-content/themes/workingnyc/includes/collection.php
+++ b/wp-content/themes/workingnyc/includes/collection.php
@@ -47,6 +47,7 @@ class Collection {
     require_once WorkingNYC\timber_post('Jobs');
     require_once WorkingNYC\timber_post('Guides');
     require_once WorkingNYC\timber_post('EmployerPrograms');
+    require_once WorkingNYC\timber_post('JobBoards');
 
     $posts = $this->fields['featured_posts_objects'];
 
@@ -69,6 +70,10 @@ class Collection {
         
         case 'employer-programs':
           $post = new WorkingNYC\EmployerPrograms($post);
+
+          break;
+        case 'job-boards':
+          $post = new WorkingNYC\JobBoards($post);
 
           break;
       }

--- a/wp-content/themes/workingnyc/timber-posts/EmployerPrograms.php
+++ b/wp-content/themes/workingnyc/timber-posts/EmployerPrograms.php
@@ -15,7 +15,7 @@ use Timber;
 use Spatie\SchemaOrg\Schema;
 
 class EmployerPrograms extends Timber\Post {
-  const SINGULAR = 'employer-program'; // todo: see where this is used
+  const SINGULAR = 'employer-program'; // used to render card in collection.twig
 
   /**
    * Constructor

--- a/wp-content/themes/workingnyc/timber-posts/JobBoards.php
+++ b/wp-content/themes/workingnyc/timber-posts/JobBoards.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * JobBoards
+ *
+ * @author NYC Opportunity
+ */
+
+namespace WorkingNYC;
+
+use Timber;
+use Spatie\SchemaOrg\Schema;
+
+class JobBoards extends Timber\Post {
+  const SINGULAR = 'job-board'; // used to render card in collection.twig
+
+  /**
+   * Constructor
+   *
+   * @return  Object  Instance of JobBoards
+   */
+  public function __construct($pid = false) {
+    if ($pid) {
+      parent::__construct($pid);
+    } else {
+      parent::__construct();
+    }
+
+    /**
+     * The ID will be null if the post doesn't exist
+     */
+
+    if (null === $this->id) {
+      return false;
+    }
+
+    /**
+     * Set Context
+     */
+
+    $this->singular = self::SINGULAR;
+
+    $this->job_board_title = $this->getTitle();
+
+    // $this->archive = get_post_type_archive_link('employer-programs');
+
+    // $this->link = $this->getLink();
+
+    // $this->schema = $this->getSchema();
+
+    return $this;
+  }
+
+  // /**
+  //  * Items returned in this object determine what is shown in the WP REST API.
+  //  * Called by the 'rest-prepare-posts.php' must use plugin.
+  //  *
+  //  * @return  Array  Items to show in the WP REST API
+  //  */
+  // public function showInRest() {
+  //   return array(
+  //     'employer_program_title' => $this->getTitle(),
+  //     'link' => $this->getLink(),
+  //     'link_label' => $this->getLinkLabel()
+  //   );
+  // }
+
+  /**
+   * Get the job board title
+   *
+   * @return  String  The job board title
+   */
+  public function getTitle() {
+    return $this->post_title;
+  }
+
+  // /**
+  //  * Get the link based on wether the resource is external or not
+  //  *
+  //  * @return  String  The full URL string to the resource
+  //  */
+  // public function getLink() {
+  //   return get_permalink($this->ID);
+  // }
+
+  // /**
+  //  * Get Schemas for the program
+  //  *
+  //  * @return  Array  Program schemas
+  //  */
+  // public function getSchema() {
+  //   $schemas = array();
+
+  //   // TODO: implement this. see Programs.php for an example
+
+  //   return $schemas;
+  // }
+}

--- a/wp-content/themes/workingnyc/timber-posts/JobBoards.php
+++ b/wp-content/themes/workingnyc/timber-posts/JobBoards.php
@@ -34,65 +34,7 @@ class JobBoards extends Timber\Post {
       return false;
     }
 
-    /**
-     * Set Context
-     */
-
     $this->singular = self::SINGULAR;
-
-    $this->job_board_title = $this->getTitle();
-
-    // $this->archive = get_post_type_archive_link('employer-programs');
-
-    // $this->link = $this->getLink();
-
-    // $this->schema = $this->getSchema();
-
     return $this;
   }
-
-  // /**
-  //  * Items returned in this object determine what is shown in the WP REST API.
-  //  * Called by the 'rest-prepare-posts.php' must use plugin.
-  //  *
-  //  * @return  Array  Items to show in the WP REST API
-  //  */
-  // public function showInRest() {
-  //   return array(
-  //     'employer_program_title' => $this->getTitle(),
-  //     'link' => $this->getLink(),
-  //     'link_label' => $this->getLinkLabel()
-  //   );
-  // }
-
-  /**
-   * Get the job board title
-   *
-   * @return  String  The job board title
-   */
-  public function getTitle() {
-    return $this->post_title;
-  }
-
-  // /**
-  //  * Get the link based on wether the resource is external or not
-  //  *
-  //  * @return  String  The full URL string to the resource
-  //  */
-  // public function getLink() {
-  //   return get_permalink($this->ID);
-  // }
-
-  // /**
-  //  * Get Schemas for the program
-  //  *
-  //  * @return  Array  Program schemas
-  //  */
-  // public function getSchema() {
-  //   $schemas = array();
-
-  //   // TODO: implement this. see Programs.php for an example
-
-  //   return $schemas;
-  // }
 }

--- a/wp-content/themes/workingnyc/views/job-boards/job-board.twig
+++ b/wp-content/themes/workingnyc/views/job-boards/job-board.twig
@@ -1,7 +1,7 @@
 {# @Type   Component #}
 {# @For    Post Type #}
 <article class="c-card h-full">
-  <div>{{ post.job_board_title }}</div>
+  <div>{{ post.post_title }}</div>
   <div>{{ post.description }}</div>
   <div>{{ post.agency }}</div>
   <a href="{{ post.cta_link.url }}" target="{{ post.cta_link.target }}">{{ post.cta_link.title }}</a>

--- a/wp-content/themes/workingnyc/views/job-boards/job-board.twig
+++ b/wp-content/themes/workingnyc/views/job-boards/job-board.twig
@@ -1,0 +1,10 @@
+{# @Type   Component #}
+{# @For    Post Type #}
+<article class="c-card h-full">
+  <div>{{ post.job_board_title }}</div>
+  <div>{{ post.description }}</div>
+  <div>{{ post.agency }}</div>
+  <a href="{{ post.cta_link.url }}" target="{{ post.cta_link.target }}">{{ post.cta_link.title }}</a>
+
+  {# <div>{{ dump(post) }}</div> #}
+</article>

--- a/wp-content/themes/workingnyc/views/job-boards/job-board.twig
+++ b/wp-content/themes/workingnyc/views/job-boards/job-board.twig
@@ -5,6 +5,4 @@
   <div>{{ post.description }}</div>
   <div>{{ post.agency }}</div>
   <a href="{{ post.cta_link.url }}" target="{{ post.cta_link.target }}">{{ post.cta_link.title }}</a>
-
-  {# <div>{{ dump(post) }}</div> #}
 </article>


### PR DESCRIPTION
Tasks 211, 221, 224

Job boards post type created, job boards cards can be added to the homepage through the CMS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new "Employer Programs" post type for job boards, enhancing the job board functionality with specific settings and attributes.
	- Added support for displaying "Job Boards" and "Employer Programs" posts, including titles, descriptions, agencies, and call-to-action links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->