### PR TITLE
Default background color

### DIFF
--- a/wp-content/themes/workingnyc/views/base.twig
+++ b/wp-content/themes/workingnyc/views/base.twig
@@ -34,7 +34,7 @@
 
   {% set navigationSpacing = 'pb-8 mb-2 tablet:pb-0 tablet:mb-0' %}
 
-  <body class="bg pb-0">
+  <body class="bg bg-scale-0 pb-0">
     {{ fn('wp_body_open') }}
 
     <a class="sr-only" href="#content">{{ __('Skip to main content', 'WNYC') }}</a>


### PR DESCRIPTION
Employer services page:

Before:
<img width="1323" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/77253705-0d59-4f61-a0cd-47732e4b93c1">


After:

<img width="1338" alt="image" src="https://github.com/CityOfNewYork/working-nyc/assets/8957837/448bb52c-2496-40bc-b567-2df6492d3fb8">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Style**
	- Updated the background styling of the website for a fresher look.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->