### PR TITLE
Enable english as default language for WKNYC settings

### DIFF
--- a/wp-content/themes/workingnyc/timber-posts/Site.php
+++ b/wp-content/themes/workingnyc/timber-posts/Site.php
@@ -64,7 +64,14 @@ class Site extends TimberSite {
      * WKNYC Settings
      */
 
+    $defaultLanguage = 'en';
+    add_filter('acf/settings/current_language', function() use($defaultLanguage) { 
+      return $defaultLanguage;
+    }, 10,1);
     $context['options'] = get_fields('options');
+    remove_filter('acf/settings/current_language', function() use($defaultLanguage) { 
+      return $defaultLanguage;
+    }, 10,1);
 
     /**
      * SVG Sprite Paths


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a default language option to enhance multilingual support in the application.
  
- **Improvements**
  - Context now includes options fetched via `get_fields` for better customization.
  - Improved handling of ACF settings with the addition and removal of filters based on the default language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->