### PR TITLE
Fix empty array error in GatherContent pull

### DIFF
--- a/wp-content/plugins/gathercontent-import/includes/classes/sync/pull.php
+++ b/wp-content/plugins/gathercontent-import/includes/classes/sync/pull.php
@@ -625,7 +625,15 @@ class Pull extends Base {
 		if ( 'text' === $this->element->type ) {
 			$terms = array_map( 'trim', explode( ',', sanitize_text_field( $this->element->value ) ) );
 		} elseif ( 'choice_checkbox' === $this->element->type ) {
-			$terms = json_decode($this->element->value);
+			$element_value = $this->element->value;
+
+			// $element_value may be an empty array instead of an empty string
+			if (empty($element_value)) {
+				$terms = array();
+			}
+			else {
+				$terms = json_decode($this->element->value);
+			}
 		} else {
 			$terms = (array) $this->element->value;
 		}

--- a/wp-content/themes/workingnyc/timber-posts/Site.php
+++ b/wp-content/themes/workingnyc/timber-posts/Site.php
@@ -65,13 +65,13 @@ class Site extends TimberSite {
      */
 
     $defaultLanguage = 'en';
-    add_filter('acf/settings/current_language', function() use($defaultLanguage) { 
+    add_filter('acf/settings/current_language', function() use ($defaultLanguage) {
       return $defaultLanguage;
-    }, 10,1);
+    }, 10, 1);
     $context['options'] = get_fields('options');
-    remove_filter('acf/settings/current_language', function() use($defaultLanguage) { 
+    remove_filter('acf/settings/current_language', function() use ($defaultLanguage) {
       return $defaultLanguage;
-    }, 10,1);
+    }, 10, 1);
 
     /**
      * SVG Sprite Paths


### PR DESCRIPTION
Same as this pull request:
https://github.com/CityOfNewYork/ACCESS-NYC/pull/444/files

To recreate:

In main branch:

- Make sure 'WP_DEBUG' is set to true in wp-config.php
- Go to CMS > GatherContent > Template Mappings > Program Page > Review items for import
- Try importing "Test item 1". It should hang at 0%
    - Go to wp-content/debug.log in your code editor. There should be an error that says `PHP Fatal error:  Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/sync/pull.php:628`
- Try importing "Test item 2". It should succeed

Switch to this branch:

- Try importing "Test item 3". It should succeed
- Try importing "Test item 4". It should succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where checkbox choices were not handled correctly during data synchronization.

- **Style**
  - Improved code consistency by standardizing spacing in function declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->