### PR TITLE
Updated Jobs Events Page

### DIFF
--- a/wp-content/themes/workingnyc/acf-json/group_5f298dbb5dda2.json
+++ b/wp-content/themes/workingnyc/acf-json/group_5f298dbb5dda2.json
@@ -607,6 +607,13 @@
                 "operator": "==",
                 "value": "template-employer-home-page.php"
             }
+        ],
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "template-employ-nyc-landing-page.php"
+            }
         ]
     ],
     "menu_order": 1,
@@ -618,5 +625,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1721672052
+    "modified": 1731619806
 }

--- a/wp-content/themes/workingnyc/acf-json/group_6661fd12e4e95.json
+++ b/wp-content/themes/workingnyc/acf-json/group_6661fd12e4e95.json
@@ -6,6 +6,7 @@
             "key": "field_6661febd61135",
             "label": "Jobs Events Header",
             "name": "jobs_events_header",
+            "aria-label": "",
             "type": "flexible_content",
             "instructions": "",
             "required": 0,
@@ -27,6 +28,7 @@
                             "key": "field_6661ffba61136",
                             "label": "Header Title",
                             "name": "header_title",
+                            "aria-label": "",
                             "type": "text",
                             "instructions": "",
                             "required": 0,
@@ -47,6 +49,7 @@
                             "key": "field_6661ffc961137",
                             "label": "Header Content",
                             "name": "header_content",
+                            "aria-label": "",
                             "type": "wysiwyg",
                             "instructions": "",
                             "required": 0,
@@ -73,177 +76,10 @@
             "max": ""
         },
         {
-            "key": "field_667076fb35544",
-            "label": "Upcoming Jobs Events",
-            "name": "upcoming_jobs_events",
-            "type": "group",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "relevanssi_exclude": 0,
-            "layout": "block",
-            "sub_fields": [
-                {
-                    "key": "field_6670887293463",
-                    "label": "Jobs Events Header",
-                    "name": "jobs_events_header",
-                    "type": "text",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "relevanssi_exclude": 0,
-                    "default_value": "",
-                    "placeholder": "",
-                    "prepend": "",
-                    "append": "",
-                    "maxlength": ""
-                },
-                {
-                    "key": "field_6670887f93464",
-                    "label": "Jobs Events",
-                    "name": "jobs_events",
-                    "type": "repeater",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "relevanssi_exclude": 0,
-                    "collapsed": "",
-                    "min": 0,
-                    "max": 0,
-                    "layout": "table",
-                    "button_label": "",
-                    "sub_fields": [
-                        {
-                            "key": "field_6670888d93465",
-                            "label": "Job Event Title",
-                            "name": "job_event_title",
-                            "type": "text",
-                            "instructions": "",
-                            "required": 0,
-                            "conditional_logic": 0,
-                            "wrapper": {
-                                "width": "",
-                                "class": "",
-                                "id": ""
-                            },
-                            "relevanssi_exclude": 0,
-                            "default_value": "",
-                            "placeholder": "",
-                            "prepend": "",
-                            "append": "",
-                            "maxlength": ""
-                        },
-                        {
-                            "key": "field_667088b593466",
-                            "label": "Job Event Date",
-                            "name": "job_event_date",
-                            "type": "date_picker",
-                            "instructions": "",
-                            "required": 0,
-                            "conditional_logic": 0,
-                            "wrapper": {
-                                "width": "",
-                                "class": "",
-                                "id": ""
-                            },
-                            "relevanssi_exclude": 0,
-                            "display_format": "F j, Y",
-                            "return_format": "F j, Y",
-                            "first_day": 1
-                        },
-                        {
-                            "key": "field_667088e893467",
-                            "label": "Job Event Start Time",
-                            "name": "job_event_start_time",
-                            "type": "time_picker",
-                            "instructions": "",
-                            "required": 0,
-                            "conditional_logic": 0,
-                            "wrapper": {
-                                "width": "",
-                                "class": "",
-                                "id": ""
-                            },
-                            "relevanssi_exclude": 0,
-                            "display_format": "g:i a",
-                            "return_format": "g:i a"
-                        },
-                        {
-                            "key": "field_667088f693468",
-                            "label": "Job Event End Time",
-                            "name": "job_event_end_time",
-                            "type": "time_picker",
-                            "instructions": "",
-                            "required": 0,
-                            "conditional_logic": 0,
-                            "wrapper": {
-                                "width": "",
-                                "class": "",
-                                "id": ""
-                            },
-                            "relevanssi_exclude": 0,
-                            "display_format": "g:i a",
-                            "return_format": "g:i a"
-                        },
-                        {
-                            "key": "field_6670891593469",
-                            "label": "Job Event Location",
-                            "name": "job_event_location",
-                            "type": "text",
-                            "instructions": "",
-                            "required": 0,
-                            "conditional_logic": 0,
-                            "wrapper": {
-                                "width": "",
-                                "class": "",
-                                "id": ""
-                            },
-                            "relevanssi_exclude": 0,
-                            "default_value": "",
-                            "placeholder": "",
-                            "prepend": "",
-                            "append": "",
-                            "maxlength": ""
-                        },
-                        {
-                            "key": "field_6670892d9346a",
-                            "label": "Job Event Link",
-                            "name": "job_event_link",
-                            "type": "link",
-                            "instructions": "",
-                            "required": 0,
-                            "conditional_logic": 0,
-                            "wrapper": {
-                                "width": "",
-                                "class": "",
-                                "id": ""
-                            },
-                            "relevanssi_exclude": 0,
-                            "return_format": "array"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "key": "field_66620011a8efb",
             "label": "Job Seekers Interest Form",
             "name": "job_seekers_interest_form",
+            "aria-label": "",
             "type": "flexible_content",
             "instructions": "",
             "required": 0,
@@ -265,6 +101,7 @@
                             "key": "field_66620029a8efc",
                             "label": "Interest Form Title",
                             "name": "interest_form_title",
+                            "aria-label": "",
                             "type": "text",
                             "instructions": "",
                             "required": 0,
@@ -285,6 +122,7 @@
                             "key": "field_6662003ea8efd",
                             "label": "Interest Form URL",
                             "name": "interest_form_url",
+                            "aria-label": "",
                             "type": "wysiwyg",
                             "instructions": "",
                             "required": 0,
@@ -329,5 +167,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1718651296
+    "modified": 1731971528
 }

--- a/wp-content/themes/workingnyc/template-employ-nyc-landing-page.php
+++ b/wp-content/themes/workingnyc/template-employ-nyc-landing-page.php
@@ -22,6 +22,14 @@ $context['meta'] = new WorkingNYC\Meta($post);
 
 //$context['sections'] = Templating\get_sections();
 
+/**
+ * Create template friendly data for collections template
+ */
+
+ $context['collections'] = array_map(function($collection) {
+    return new WorkingNYC\Collection($collection);
+  }, Templating\get_featured_posts($post->ID));
+
 $context['upcoming_events'] = Templating\get_upcoming_events();
 
 $context['events_form'] = Templating\get_events_form();

--- a/wp-content/themes/workingnyc/views/components/collection.twig
+++ b/wp-content/themes/workingnyc/views/components/collection.twig
@@ -13,11 +13,14 @@
     {% if this.display == 'cards' %}
 
       {% if this.heading or this.description %}
-       
+
+        {% if is_nyc_landing %}
+            <h3 class="text-[30px] desktop:text-[33.18px] tablet:text-[30px]" font-[600]">{{ this.heading }}</h3>
+        {% else %}
             <h2 class="text-[26px] tablet:text-[40px] desktop:text-[44px] text-alt mt-0 mb-4">{{ this.heading }}</h2>
 
             {{ this.description }}
-  
+        {% endif %}
       {% endif %}
 
       {% if this.posts %}
@@ -49,7 +52,7 @@
                 </div>
               {% elseif post.post_type == 'jobs-events' %}
                 
-                  {% include 'jobs-events/jobs-event.twig' with {this: post, site:site } only %}
+                  {% include 'jobs-events/jobs-event.twig' with {this: post, is_nyc_landing:is_nyc_landing, site:site } only %}
               
               {% else %}
               <div class="max-w-full">

--- a/wp-content/themes/workingnyc/views/employ-nyc-landing-page.twig
+++ b/wp-content/themes/workingnyc/views/employ-nyc-landing-page.twig
@@ -53,57 +53,17 @@
     </div>
     {% endif %}
 
-    {% if upcoming_events %}
-    
     <div class="bg-scale-0">
-      <div class="site-max-width pb-6">
-        <div class="bg-scale-0 sticky top-0 z-10 pb-4">
-          <h3 class="text-[30px] desktop:text-[33.18px] tablet:text-[30px]" font-[600]">{{ upcoming_events.jobs_events_header }}</h3>
-        </div>
-        <div class="grid desktop:grid-cols-3 tablet:grid-cols-2  gap-2 desktop:gap-3">
-          {% for section in upcoming_events.jobs_events %}
-            <div class="transform-none p-[32px] rounded-[5px] border-2 border-[#F0F6FA] desktop:relative tablet:relative">
-              <p class="text-[22px] font-[700] border-b-2 border-[#ECEFF2] pb-[16px] mb-[0px]">{{ section.job_event_title}}</p>
-              <div class="pt-[24px] desktop:min-h-[173px] tablet:min-h-[198px] min-h-[170px] pb-[24px]">
-                <p class="flex mb-[10px]">
-                  <svg aria-hidden="true" class="icon-ui c-card__feature-icon w-[24px] h-[24px]">
-                    <use href="#lucide-calendar"></use>
-                  </svg>
-                  {{ section.job_event_date}}
-                </p>
-                <p class="flex mb-[10px]">
-                  <svg aria-hidden="true" class="icon-ui c-card__feature-icon w-[24px] h-[24px]">
-                    <use href="#temp-lucide-clock"></use>
-                  </svg>
-                  <span>{{ section.job_event_start_time}}</span>
-                  <span class="pl-[8px] pr-[8px]">to</span>
-                  <span>{{ section.job_event_end_time}}</span>
-                </p>
-                <p class="flex mb-[24px]">
-                  <svg aria-hidden="true" class="icon-ui c-card__feature-icon w-[24px] h-[24px]">
-                    <use href="#lucide-map-pin"></use>
-                  </svg>{{ section.job_event_location}}
-                </p>
-                <div class="desktop:absolute desktop:bottom-[32px] tablet:absolute tablet:bottom-[32px]">
-                  <a href="{{ function('convert_link_locale', section.job_event_link.url , site.site_url, site.url) }}" target="{{ section.job_event_link.target }}" class="c-card__header-link hover:text-[#080707] visited:text-[#30374F] underline">
-                    <p class="c-card__title text-[20px] flex leading-[22px] text-[20px]">
-                      <span>{{ section.job_event_link.title }}</span>
-                      <svg aria-hidden="true" class="icon-ui w-[24px] h-[24px] ml-[4px]">
-                        <use href="#lucide-arrow-right"></use>
-                      </svg>
-                    </p>
-                  </a>
-                </div>
-                
-              </div>
-            </div>
+      <div>
+        {# Collections #}
+        {% if collections %}
+          {% for collection in collections %}
+            {% include collection.template with {this: collection, is_nyc_landing: true, site: site} only %}
           {% endfor %}
-        </div>
+        {% endif %}
+
       </div>
     </div>
-    {% endif %}
-
-    
 
     {% if events_form %}
     <div class="bg-scale-0">

--- a/wp-content/themes/workingnyc/views/jobs-events/jobs-event.twig
+++ b/wp-content/themes/workingnyc/views/jobs-events/jobs-event.twig
@@ -28,5 +28,17 @@
             <use href="#lucide-map-pin"></use>
             </svg>{{ this.jobs_event_location}}
         </p>
+        {% if is_nyc_landing %}
+            <div class="desktop:absolute desktop:bottom-[32px] tablet:absolute tablet:bottom-[32px]">
+                <a href="{{ function('convert_link_locale', this.jobs_event_link.url , site.site_url, site.url) }}" target="{{ this.jobs_event_link.target }}" class="c-card__header-link hover:text-[#080707] visited:text-[#30374F] underline">
+                    <p class="c-card__title text-[20px] flex leading-[22px] text-[20px]">
+                        <span>{{ this.jobs_event_link.title }}</span>
+                        <svg aria-hidden="true" class="icon-ui w-[24px] h-[24px] ml-[4px]">
+                        <use href="#lucide-arrow-right"></use>
+                        </svg>
+                    </p>
+                </a>
+            </div>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
1. Made the "Home page sections" filed visible in employ-nyc-landing template.
2. Updated the template, collection and Jobs-event twig files.
3. Removed the existing Jobs events in jobs-events page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced "Home Page Sections" functionality with a new location condition for the NYC landing page template.
  - Added a collections section to the NYC landing page, displaying featured posts.
  - Conditional heading display based on the NYC landing page context for improved visual hierarchy.
  - New link display for job events on the NYC landing page, providing additional information.
  - Improved accessibility with added `aria-label` attributes for various fields in the Job Events configuration.

- **Bug Fixes**
  - Removed outdated upcoming job events section from the NYC landing page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->