### PR TITLE
Fixed empty card issue in program guide page

### DIFF
--- a/wp-content/themes/workingnyc/views/programs/program.twig
+++ b/wp-content/themes/workingnyc/views/programs/program.twig
@@ -24,7 +24,7 @@
       {%endif%}
   </header>
 
-{% if post.status and not is_home %}
+{% if not is_home %}
   <div class="c-card__body py-3 px-5 tablet:py-5 min-h-[206px] justify-between">
     <div class="mb-0">
       


### PR DESCRIPTION
<img width="1568" alt="Screen Shot 2024-12-10 at 9 42 49 PM" src="https://github.com/user-attachments/assets/2313b408-7603-4b0a-ba01-b3bffa1530f8">


Removed the recruitment_status condition to show the program details on card.