### PR TITLE
Fix 404 page redirection to new landing page

### DIFF
--- a/wp-content/themes/workingnyc/index.php
+++ b/wp-content/themes/workingnyc/index.php
@@ -12,25 +12,51 @@
 /**
  * Context
  */
+require_once WorkingNYC\timber_post('Announcements');
 
  $context = Timber::get_context();
 
  $post = Timber::get_post(get_option('page_on_front'));
  
  $context['post'] = $post;
- 
- $context['hide_jobseeker_and_employer_navigation'] = true;
+
+ //Set the announcement context from new landing page
+ $context['announcements'] = array_map(function($post) {
+    return new WorkingNYC\Announcements($post);
+ }, Timber::get_posts(array(
+  'posts_per_page' => 4,
+  'post_type' => 'announcements',
+  'orderby' => 'menu_order',
+  'order' => 'ASC',
+ )));
+
+//Set the 404 page title to landing page title
+
+$current_page_title = $post->page_title;
+
+if (!empty($current_page_title)) {
+  add_filter('document_title', function() use ($current_page_title) {
+    return esc_html($current_page_title);
+    ;
+  }, 10, 1);
+}
  
  /**
   * Set Meta context
   */
  
  $context['meta'] = new WorkingNYC\Meta($post);
+
+ //Set the collections context of new Landing page
+
+ $context['collections'] = array_map(function($collection) {
+    return new WorkingNYC\Collection($collection);
+  }, Templating\get_featured_posts($post->ID));
  
  /**
-  * Render the view
+  * Render the view of new Landing page.
   */
  
- $compiled = new WorkingNYC\CompileImgPreload('talent-portal-landing-page.twig', $context);
+ $compiled = new WorkingNYC\CompileImgPreload('home.twig', $context);
  
  echo $compiled->html;

--- a/wp-content/themes/workingnyc/index.php
+++ b/wp-content/themes/workingnyc/index.php
@@ -1,13 +1,12 @@
 <?php
 
 /**
- * Index template and Homepage
+ * Index template
  *
- * A fallback list template used if a more specific template is not available
+ * A fallback list template used if a more specific template is not available (i.e., this is the 404 page template)
+ * Most code is copied from template-home-page.php
  *
  */
-
-// Use the landing page template but with the homepage
 
 /**
  * Context

--- a/wp-content/themes/workingnyc/index.php
+++ b/wp-content/themes/workingnyc/index.php
@@ -24,22 +24,22 @@ require_once WorkingNYC\timber_post('Announcements');
  $context['announcements'] = array_map(function($post) {
     return new WorkingNYC\Announcements($post);
  }, Timber::get_posts(array(
-  'posts_per_page' => 4,
-  'post_type' => 'announcements',
-  'orderby' => 'menu_order',
-  'order' => 'ASC',
+   'posts_per_page' => 4,
+   'post_type' => 'announcements',
+   'orderby' => 'menu_order',
+   'order' => 'ASC',
  )));
 
 //Set the 404 page title to landing page title
 
-$current_page_title = $post->page_title;
+ $current_page_title = $post->page_title;
 
-if (!empty($current_page_title)) {
-  add_filter('document_title', function() use ($current_page_title) {
+ if (!empty($current_page_title)) {
+   add_filter('document_title', function() use ($current_page_title) {
     return esc_html($current_page_title);
     ;
-  }, 10, 1);
-}
+   }, 10, 1);
+ }
  
  /**
   * Set Meta context
@@ -51,7 +51,7 @@ if (!empty($current_page_title)) {
 
  $context['collections'] = array_map(function($collection) {
     return new WorkingNYC\Collection($collection);
-  }, Templating\get_featured_posts($post->ID));
+ }, Templating\get_featured_posts($post->ID));
  
  /**
   * Render the view of new Landing page.

--- a/wp-content/themes/workingnyc/template-employ-nyc-landing-page.php
+++ b/wp-content/themes/workingnyc/template-employ-nyc-landing-page.php
@@ -28,11 +28,11 @@ $context['meta'] = new WorkingNYC\Meta($post);
 
  //Show Jobs events when collection is added on CMS
  
- if(Templating\get_featured_posts($post->ID)){
-   $context['collections'] = array_map(function($collection) {
-      return new WorkingNYC\Collection($collection);
-   }, Templating\get_featured_posts($post->ID));
- }
+if (Templating\get_featured_posts($post->ID)) {
+  $context['collections'] = array_map(function($collection) {
+     return new WorkingNYC\Collection($collection);
+  }, Templating\get_featured_posts($post->ID));
+}
 
  $context['upcoming_events'] = Templating\get_upcoming_events();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated announcements into the context, displaying the latest four announcements.
	- Updated context to include collections of featured posts related to the current post.
	- Changed the rendering template from `talent-portal-landing-page.twig` to `home.twig`.

- **Bug Fixes**
	- Improved readability of the conditional structure in the landing page template without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->